### PR TITLE
Backporting Anaconda 22.05 from Spack upstream

### DIFF
--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -21,6 +21,16 @@ class Anaconda3(Package):
 
     maintainers = ['ajkotobi']
 
+    version(
+        "2022.05",
+        sha256="a7c0afe862f6ea19a596801fc138bde0463abcbce1b753e8d5c474b506a2db2d",
+        expand=False,
+    )
+    version(
+        "2021.11",
+        sha256="fedf9e340039557f7b5e8a8a86affa9d299f5e9820144bd7b92ae9f7ee08ac60",
+        expand=False,
+    )
     version('2021.05', sha256='2751ab3d678ff0277ae80f9e8a74f218cfc70fe9a9cdc7bb1c137d7e47e33d53', expand=False)
     version('2020.11', sha256='cf2ff493f11eaad5d09ce2b4feaa5ea90db5174303d5b3fe030e16d29aeef7de', expand=False)
     version('2020.07', sha256='38ce717758b95b3bd0b1797cc6ccfb76f29a90c25bdfa50ee45f11e583edfdbf', expand=False)


### PR DESCRIPTION
- upstream file: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/anaconda3/package.py
- tested in https://github.com/fangohr/spack-ci-anaconda3