### PR TITLE
Octopus  pull from upstream

### DIFF
--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -36,15 +36,16 @@ class Octopus(AutotoolsPackage, CudaPackage):
     version("6.0", sha256="4a802ee86c1e06846aa7fa317bd2216c6170871632c9e03d020d7970a08a8198")
     version("5.0.1", sha256="3423049729e03f25512b1b315d9d62691cd0a6bd2722c7373a61d51bfbee14e0")
 
-    version("develop", branch="develop")
+    version("develop", branch="main")
 
-    variant("scalapack", default=False, description="Compile with Scalapack")
+    variant("mpi", default=True, description="Build with MPI support")
+    variant("scalapack", default=False, when="+mpi", description="Compile with Scalapack")
     variant("metis", default=False, description="Compile with METIS")
-    variant("parmetis", default=False, description="Compile with ParMETIS")
+    variant("parmetis", default=False, when="+mpi", description="Compile with ParMETIS")
     variant("netcdf", default=False, description="Compile with Netcdf")
     variant("arpack", default=False, description="Compile with ARPACK")
     variant("cgal", default=False, description="Compile with CGAL library support")
-    variant("pfft", default=False, description="Compile with PFFT")
+    variant("pfft", default=False, when="+mpi", description="Compile with PFFT")
     # poke here refers to https://gitlab.e-cam2020.eu/esl/poke
     # variant('poke', default=False,
     #         description='Compile with poke (not available in spack yet)')
@@ -60,31 +61,43 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("automake", type="build", when="@develop")
     depends_on("libtool", type="build", when="@develop")
     depends_on("m4", type="build", when="@develop")
+    depends_on("mpi", when="+mpi")
 
     depends_on("blas")
     depends_on("gsl@1.9:")
     depends_on("lapack")
+
+    # The library of exchange and correlation functionals.
     depends_on("libxc@2:2", when="@:5")
     depends_on("libxc@2:3", when="@6:7")
     depends_on("libxc@2:4", when="@8:9")
     depends_on("libxc@5.1.0:", when="@10:")
     depends_on("libxc@5.1.0:", when="@develop")
-    depends_on("mpi")
-    depends_on("fftw@3:+mpi+openmp", when="@8:9")
-    depends_on("fftw-api@3:+mpi+openmp", when="@10:")
+    with when("+mpi"):  # list all the parallel dependencies
+        depends_on("fftw@3:+mpi+openmp", when="@8:9")  # FFT library
+        depends_on("fftw-api@3:+mpi+openmp", when="@10:")
+        depends_on("libvdwxc+mpi", when="+libvdwxc")
+        depends_on("arpack-ng+mpi", when="+arpack")
+        depends_on("elpa+mpi", when="+elpa")
+        depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+
+    with when("~mpi"):  # list all the serial dependencies
+        depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
+        depends_on("fftw-api@3:+openmp~mpi", when="@10:")
+        depends_on("libvdwxc~mpi", when="+libvdwxc")
+        depends_on("arpack-ng~mpi", when="+arpack")
+        depends_on("elpa~mpi", when="+elpa")
+        depends_on("netcdf-fortran ^netcdf-c~~mpi", when="+netcdf")
+
     depends_on("py-numpy", when="+python")
     depends_on("py-mpi4py", when="+python")
     depends_on("metis@5:+int64", when="+metis")
     depends_on("parmetis+int64", when="+parmetis")
     depends_on("scalapack", when="+scalapack")
-    depends_on("netcdf-fortran", when="+netcdf")
-    depends_on("arpack-ng", when="+arpack")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
     depends_on("likwid", when="+likwid")
-    depends_on("libvdwxc", when="+libvdwxc")
     depends_on("libyaml", when="+libyaml")
-    depends_on("elpa", when="+elpa")
     depends_on("nlopt", when="+nlopt")
 
     # optional dependencies:
@@ -103,12 +116,25 @@ class Octopus(AutotoolsPackage, CudaPackage):
                 "--with-lapack=%s" % lapack.ld_flags,
                 "--with-gsl-prefix=%s" % spec["gsl"].prefix,
                 "--with-libxc-prefix=%s" % spec["libxc"].prefix,
-                "CC=%s" % spec["mpi"].mpicc,
-                "FC=%s" % spec["mpi"].mpifc,
-                "--enable-mpi",
                 "--enable-openmp",
             ]
         )
+        if "+mpi" in self.spec:  # we build with MPI
+            args.extend(
+                [
+                    "--enable-mpi",
+                    "CC=%s" % self.spec["mpi"].mpicc,
+                    "FC=%s" % self.spec["mpi"].mpifc,
+                ]
+            )
+        else:
+            args.extend(
+                [
+                    "CC=%s" % self.compiler.cc,
+                    "FC=%s" % self.compiler.fc,
+                ]
+            )
+
         if "^fftw" in spec:
             args.append("--with-fftw-prefix=%s" % spec["fftw"].prefix)
         elif "^mkl" in spec:


### PR DESCRIPTION
The commits splitting mpi and serial versions were not ported to our branch, hence I had problems installing octopus within the toolchain. Updated commits from upstream to solve this.
