### PR TITLE
make anaconda@22.10 available by pulling this file from spack/spack

### DIFF
--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -22,6 +22,11 @@ class Anaconda3(Package):
 
     maintainers = ["ajkotobi"]
 
+    version(
+        "2022.10",
+        sha256="e7ecbccbc197ebd7e1f211c59df2e37bc6959d081f2235d387e08c9026666acd",
+        expand=False,
+    )
     version(
         "2022.05",
         sha256="a7c0afe862f6ea19a596801fc138bde0463abcbce1b753e8d5c474b506a2db2d",

--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)


### PR DESCRIPTION
We need this to offer anaconda3 22.10 at MPSD HPC (currently 22.05 is the most recent option).

File taken from develop branch, commit a426db06e7db90d2c07f4862841f9b940a9b9d1f
Date:   Tue Jan 31 17:27:16 2023 +0100