### PR TITLE
Pull anaconda3 vs 22.10 from upstream

### DIFF
--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -22,6 +22,11 @@ class Anaconda3(Package):
 
     maintainers = ["ajkotobi"]
 
+    version(
+        "2022.10",
+        sha256="e7ecbccbc197ebd7e1f211c59df2e37bc6959d081f2235d387e08c9026666acd",
+        expand=False,
+    )
     version(
         "2022.05",
         sha256="a7c0afe862f6ea19a596801fc138bde0463abcbce1b753e8d5c474b506a2db2d",


### PR DESCRIPTION
Reapply upstream commits (as was done in https://github.com/mpsd-computational-science/spack/pull/4) to mpsd/v0.19