### PR TITLE
Fix Psolver compilation issue.

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -23,32 +23,33 @@ class BigdftAtlab(AutotoolsPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("mpi", when="+mpi")
     depends_on("openbabel", when="+openbabel")
 
     for vers in ["1.8.1", "1.8.2", "1.8.3", "1.9.0", "1.9.1", "1.9.2", "develop"]:
         depends_on("bigdft-futile@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "atlab"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "atlab"
 
     def configure_args(self):
         spec = self.spec
         prefix = self.prefix
 
-        openmp_flag = []
+        fcflags = []
         if "+openmp" in spec:
-            openmp_flag.append(self.compiler.openmp_flag)
+            fcflags.append(self.compiler.openmp_flag)
+
+        if self.spec.satisfies("%gcc@10:"):
+            fcflags.append("-fallow-argument-mismatch")
 
         args = [
-            "FCFLAGS=%s" % " ".join(openmp_flag),
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
-            "--with-futile-incs=%s" % spec["bigdft-futile"].prefix.include,
+            "FCFLAGS=%s" % " ".join(fcflags),
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
+            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",

--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -49,7 +49,7 @@ class BigdftAtlab(AutotoolsPackage):
         args = [
             "FCFLAGS=%s" % " ".join(fcflags),
             "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
-            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
+            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags+"/futile",
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -27,6 +27,10 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -48,13 +52,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-libabinit@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "bigdft"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "bigdft"
 
     def configure_args(self):
         spec = self.spec
@@ -77,13 +75,13 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
-            "--with-chess-libs=%s" % spec["bigdft-chess"].prefix.lib,
+            "--with-chess-libs=%s" % spec["bigdft-chess"].libs.ld_flags,
             "--with-chess-incs=%s" % spec["bigdft-chess"].headers.include_flags,
-            "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
+            "--with-psolver-libs=%s" % spec["bigdft-psolver"].libs.ld_flags,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,
-            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].prefix.lib,
+            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].libs.ld_flags,
             "--with-libABINIT-incs=%s" % spec["bigdft-libabinit"].headers.include_flags,
             "--with-libgain-libs=%s" % spec["libgain"].libs.ld_flags,
             "--with-libgain-incs=%s" % spec["libgain"].headers.include_flags,

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -28,6 +28,10 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -38,13 +42,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     depends_on("py-pyyaml")
     depends_on("mpi", when="+mpi")
 
-    build_directory = "futile"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "futile"
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -27,6 +27,11 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -42,13 +47,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     for vers in ["1.8.3", "1.9.0", "1.9.1", "1.9.2", "develop"]:
         depends_on("bigdft-atlab@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "psolver"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "psolver"
 
     def configure_args(self):
         spec = self.spec
@@ -71,7 +70,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -22,6 +22,10 @@ class BigdftSpred(AutotoolsPackage):
     version("1.8.2", sha256="042e5a3b478b1a4c050c450a9b1be7bcf8e13eacbce4759b7f2d79268b298d61")
     version("1.8.1", sha256="e09ff0ba381f6ffbe6a3c0cb71db5b73117874beb41f22a982a7e5ba32d018b3")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
@@ -41,13 +45,7 @@ class BigdftSpred(AutotoolsPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-core@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "spred"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "spred"
 
     def configure_args(self):
         spec = self.spec
@@ -70,7 +68,7 @@ class BigdftSpred(AutotoolsPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,


### PR DESCRIPTION
Psolver dosent compile on the current v0.19 branch, this MR selectively chooses from 
https://github.com/spack/spack/commit/d20f2841009eb037344e73516d38716769643e4b such that the commits are compatible with our fork.