### PR TITLE
[23b] Apply MPSD patches to spack v19.2 release

### DIFF
--- a/var/spack/repos/builtin/packages/anaconda3/package.py
+++ b/var/spack/repos/builtin/packages/anaconda3/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -22,6 +22,11 @@ class Anaconda3(Package):
 
     maintainers = ["ajkotobi"]
 
+    version(
+        "2022.10",
+        sha256="e7ecbccbc197ebd7e1f211c59df2e37bc6959d081f2235d387e08c9026666acd",
+        expand=False,
+    )
     version(
         "2022.05",
         sha256="a7c0afe862f6ea19a596801fc138bde0463abcbce1b753e8d5c474b506a2db2d",

--- a/var/spack/repos/builtin/packages/berkeleygw/package.py
+++ b/var/spack/repos/builtin/packages/berkeleygw/package.py
@@ -46,7 +46,6 @@ class Berkeleygw(MakefilePackage):
 
     depends_on("blas")
     depends_on("lapack")
-    depends_on("scalapack")
     depends_on("mpi", when="+mpi")
     depends_on("hdf5+fortran+hl", when="+hdf5~mpi")
     depends_on("hdf5+fortran+hl+mpi", when="+hdf5+mpi")
@@ -84,7 +83,10 @@ class Berkeleygw(MakefilePackage):
         tar("-x", "-f", self.stage.archive_file, "--strip-components=1")
 
         # get generic arch.mk template
-        copy(join_path(self.stage.source_path, "config", "generic.mpi.linux.mk"), "arch.mk")
+        if "+mpi" in spec:
+            copy(join_path(self.stage.source_path, "config", "generic.mpi.linux.mk"), "arch.mk")
+        else:
+            copy(join_path(self.stage.source_path, "config", "generic.serial.linux.mk"), "arch.mk")
 
         if self.version == Version("2.1"):
             # don't try to install missing file
@@ -125,8 +127,9 @@ class Berkeleygw(MakefilePackage):
             paraflags.append("-DOMP")
             spec.compiler_flags["fflags"].append(self.compiler.openmp_flag)
 
-        buildopts.append("C_PARAFLAG=-DPARA")
-        buildopts.append("PARAFLAG=%s" % " ".join(paraflags))
+        if "+mpi" in spec:
+            buildopts.append("C_PARAFLAG=-DPARA")
+            buildopts.append("PARAFLAG=%s" % " ".join(paraflags))
 
         debugflag = ""
         if "+debug" in spec:
@@ -135,8 +138,12 @@ class Berkeleygw(MakefilePackage):
             debugflag += "-DVERBOSE "
         buildopts.append("DEBUGFLAG=%s" % debugflag)
 
-        buildopts.append("LINK=%s" % spec["mpi"].mpifc)
-        buildopts.append("C_LINK=%s" % spec["mpi"].mpicxx)
+        if "+mpi" in spec:
+            buildopts.append("LINK=%s" % spec["mpi"].mpifc)
+            buildopts.append("C_LINK=%s" % spec["mpi"].mpicxx)
+        else:
+            buildopts.append("LINK=%s" % spack_fc)
+            buildopts.append("C_LINK=%s" % spack_cxx)
 
         buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
         buildopts.append("C_OPTS=%s" % " ".join(spec.compiler_flags["cflags"]))
@@ -157,12 +164,18 @@ class Berkeleygw(MakefilePackage):
         if spec.satisfies("%intel"):
             buildopts.append("COMPFLAG=-DINTEL")
             buildopts.append("MOD_OPT=-module ")
-            buildopts.append("F90free=%s -free" % spec["mpi"].mpifc)
             buildopts.append("FCPP=cpp -C -P -ffreestanding")
-            buildopts.append("C_COMP=%s" % spec["mpi"].mpicc)
-            buildopts.append("CC_COMP=%s" % spec["mpi"].mpicxx)
-            buildopts.append("BLACSDIR=%s" % spec["scalapack"].libs)
-            buildopts.append("BLACS=%s" % spec["scalapack"].libs.ld_flags)
+            if "+mpi" in spec:
+                buildopts.append("F90free=%s -free" % spec["mpi"].mpifc)
+                buildopts.append("C_COMP=%s" % spec["mpi"].mpicc)
+                buildopts.append("CC_COMP=%s" % spec["mpi"].mpicxx)
+                if "+scalapack" in spec:
+                    buildopts.append("BLACSDIR=%s" % spec["scalapack"].libs)
+                    buildopts.append("BLACS=%s" % spec["scalapack"].libs.ld_flags)
+            else:
+                buildopts.append("F90free=%s -free" % spack_fc)
+                buildopts.append("C_COMP=%s" % spack_cc)
+                buildopts.append("CC_COMP=%s" % spack_cxx)
             buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
         elif spec.satisfies("%gcc"):
             c_flags = "-std=c99"
@@ -174,10 +187,15 @@ class Berkeleygw(MakefilePackage):
                 f90_flags += " -fallow-argument-mismatch"
             buildopts.append("COMPFLAG=-DGNU")
             buildopts.append("MOD_OPT=-J ")
-            buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
             buildopts.append("FCPP=cpp -C -nostdinc")
-            buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
-            buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
+            if "+mpi" in spec:
+                buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
+                buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
+                buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
+            else:
+                buildopts.append("F90free=%s %s" % (spack_fc, f90_flags))
+                buildopts.append("C_COMP=%s %s" % (spack_cc, c_flags))
+                buildopts.append("CC_COMP=%s %s" % (spack_cxx, cxx_flags))
             buildopts.append("FOPTS=%s" % " ".join(spec.compiler_flags["fflags"]))
         elif spec.satisfies("%fj"):
             c_flags = "-std=c99"
@@ -185,10 +203,15 @@ class Berkeleygw(MakefilePackage):
             f90_flags = "-Free"
             buildopts.append("COMPFLAG=")
             buildopts.append("MOD_OPT=-module ")
-            buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
             buildopts.append("FCPP=cpp -C -nostdinc")
-            buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
-            buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
+            if "+mpi" in spec:
+                buildopts.append("F90free=%s %s" % (spec["mpi"].mpifc, f90_flags))
+                buildopts.append("C_COMP=%s %s" % (spec["mpi"].mpicc, c_flags))
+                buildopts.append("CC_COMP=%s %s" % (spec["mpi"].mpicxx, cxx_flags))
+            else:
+                buildopts.append("F90free=%s %s" % (spack_fc, f90_flags))
+                buildopts.append("C_COMP=%s %s" % (spack_cc, c_flags))
+                buildopts.append("CC_COMP=%s %s" % (spack_cxx, cxx_flags))
             buildopts.append(
                 "FOPTS=-Kfast -Knotemparraystack %s" % " ".join(spec.compiler_flags["fflags"])
             )

--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -23,32 +23,33 @@ class BigdftAtlab(AutotoolsPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("mpi", when="+mpi")
     depends_on("openbabel", when="+openbabel")
 
     for vers in ["1.8.1", "1.8.2", "1.8.3", "1.9.0", "1.9.1", "1.9.2", "develop"]:
         depends_on("bigdft-futile@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "atlab"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "atlab"
 
     def configure_args(self):
         spec = self.spec
         prefix = self.prefix
 
-        openmp_flag = []
+        fcflags = []
         if "+openmp" in spec:
-            openmp_flag.append(self.compiler.openmp_flag)
+            fcflags.append(self.compiler.openmp_flag)
+
+        if self.spec.satisfies("%gcc@10:"):
+            fcflags.append("-fallow-argument-mismatch")
 
         args = [
-            "FCFLAGS=%s" % " ".join(openmp_flag),
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
-            "--with-futile-incs=%s" % spec["bigdft-futile"].prefix.include,
+            "FCFLAGS=%s" % " ".join(fcflags),
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
+            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",

--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -49,7 +49,7 @@ class BigdftAtlab(AutotoolsPackage):
         args = [
             "FCFLAGS=%s" % " ".join(fcflags),
             "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
-            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
+            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags+"/futile",
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",

--- a/var/spack/repos/builtin/packages/bigdft-core/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-core/package.py
@@ -27,6 +27,10 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
     variant("scalapack", default=True, description="Enable SCALAPACK support")
     variant("openbabel", default=False, description="Enable detection of openbabel compilation")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -48,13 +52,7 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-libabinit@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "bigdft"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "bigdft"
 
     def configure_args(self):
         spec = self.spec
@@ -77,13 +75,13 @@ class BigdftCore(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
-            "--with-chess-libs=%s" % spec["bigdft-chess"].prefix.lib,
+            "--with-chess-libs=%s" % spec["bigdft-chess"].libs.ld_flags,
             "--with-chess-incs=%s" % spec["bigdft-chess"].headers.include_flags,
-            "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
+            "--with-psolver-libs=%s" % spec["bigdft-psolver"].libs.ld_flags,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,
-            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].prefix.lib,
+            "--with-libABINIT-libs=%s" % spec["bigdft-libabinit"].libs.ld_flags,
             "--with-libABINIT-incs=%s" % spec["bigdft-libabinit"].headers.include_flags,
             "--with-libgain-libs=%s" % spec["libgain"].libs.ld_flags,
             "--with-libgain-incs=%s" % spec["libgain"].headers.include_flags,

--- a/var/spack/repos/builtin/packages/bigdft-futile/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-futile/package.py
@@ -28,6 +28,10 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -38,13 +42,7 @@ class BigdftFutile(AutotoolsPackage, CudaPackage):
     depends_on("py-pyyaml")
     depends_on("mpi", when="+mpi")
 
-    build_directory = "futile"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "futile"
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/bigdft-psolver/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-psolver/package.py
@@ -27,6 +27,11 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
+
     depends_on("python@:2.8", type=("build", "run"), when="@:1.8.3")
     depends_on("python@3.0:", type=("build", "run"), when="@1.9.0:")
     depends_on("python@3.0:", type=("build", "run"), when="@develop")
@@ -42,13 +47,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
     for vers in ["1.8.3", "1.9.0", "1.9.1", "1.9.2", "develop"]:
         depends_on("bigdft-atlab@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "psolver"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "psolver"
 
     def configure_args(self):
         spec = self.spec
@@ -71,7 +70,7 @@ class BigdftPsolver(AutotoolsPackage, CudaPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,

--- a/var/spack/repos/builtin/packages/bigdft-spred/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-spred/package.py
@@ -22,6 +22,10 @@ class BigdftSpred(AutotoolsPackage):
     version("1.8.2", sha256="042e5a3b478b1a4c050c450a9b1be7bcf8e13eacbce4759b7f2d79268b298d61")
     version("1.8.1", sha256="e09ff0ba381f6ffbe6a3c0cb71db5b73117874beb41f22a982a7e5ba32d018b3")
 
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+
     variant("mpi", default=True, description="Enable MPI support")
     variant("openmp", default=True, description="Enable OpenMP support")
     variant("scalapack", default=True, description="Enable SCALAPACK support")
@@ -41,13 +45,7 @@ class BigdftSpred(AutotoolsPackage):
         depends_on("bigdft-psolver@{0}".format(vers), when="@{0}".format(vers))
         depends_on("bigdft-core@{0}".format(vers), when="@{0}".format(vers))
 
-    build_directory = "spred"
-
-    def autoreconf(self, spec, prefix):
-        autoreconf = which("autoreconf")
-
-        with working_dir(self.build_directory):
-            autoreconf("-fi")
+    configure_directory = "spred"
 
     def configure_args(self):
         spec = self.spec
@@ -70,7 +68,7 @@ class BigdftSpred(AutotoolsPackage):
             "FCFLAGS=%s" % " ".join(openmp_flag),
             "--with-ext-linalg=%s" % " ".join(linalg),
             "--with-pyyaml-path=%s" % pyyaml,
-            "--with-futile-libs=%s" % spec["bigdft-futile"].prefix.lib,
+            "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
             "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
             "--with-psolver-libs=%s" % spec["bigdft-psolver"].prefix.lib,
             "--with-psolver-incs=%s" % spec["bigdft-psolver"].headers.include_flags,

--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -16,6 +16,8 @@ class Nfft(AutotoolsPackage):
 
     version("3.4.1", sha256="1cf6060eec0afabbbba323929d8222397a77fa8661ca74927932499db26b4aaf")
     version("3.3.2", sha256="9dcebd905a82c4f0a339d0d5e666b68c507169d9173b66d5ac588aae5d50b57c")
+    version("3.2.4", sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
+            url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz")
 
     depends_on("fftw")
 

--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -16,8 +16,11 @@ class Nfft(AutotoolsPackage):
 
     version("3.4.1", sha256="1cf6060eec0afabbbba323929d8222397a77fa8661ca74927932499db26b4aaf")
     version("3.3.2", sha256="9dcebd905a82c4f0a339d0d5e666b68c507169d9173b66d5ac588aae5d50b57c")
-    version("3.2.4", sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
-            url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz")
+    version(
+        "3.2.4",
+        sha256="31932438bd28609bcc32bef23830994fe6ac26d411d2077cde782faa5d21207e",
+        url="https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-3.2.4.tar.gz",
+    )
 
     depends_on("fftw")
 

--- a/var/spack/repos/builtin/packages/octopus/package.py
+++ b/var/spack/repos/builtin/packages/octopus/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -36,15 +36,16 @@ class Octopus(AutotoolsPackage, CudaPackage):
     version("6.0", sha256="4a802ee86c1e06846aa7fa317bd2216c6170871632c9e03d020d7970a08a8198")
     version("5.0.1", sha256="3423049729e03f25512b1b315d9d62691cd0a6bd2722c7373a61d51bfbee14e0")
 
-    version("develop", branch="develop")
+    version("develop", branch="main")
 
-    variant("scalapack", default=False, description="Compile with Scalapack")
+    variant("mpi", default=True, description="Build with MPI support")
+    variant("scalapack", default=False, when="+mpi", description="Compile with Scalapack")
     variant("metis", default=False, description="Compile with METIS")
-    variant("parmetis", default=False, description="Compile with ParMETIS")
+    variant("parmetis", default=False, when="+mpi", description="Compile with ParMETIS")
     variant("netcdf", default=False, description="Compile with Netcdf")
     variant("arpack", default=False, description="Compile with ARPACK")
     variant("cgal", default=False, description="Compile with CGAL library support")
-    variant("pfft", default=False, description="Compile with PFFT")
+    variant("pfft", default=False, when="+mpi", description="Compile with PFFT")
     # poke here refers to https://gitlab.e-cam2020.eu/esl/poke
     # variant('poke', default=False,
     #         description='Compile with poke (not available in spack yet)')
@@ -60,31 +61,43 @@ class Octopus(AutotoolsPackage, CudaPackage):
     depends_on("automake", type="build", when="@develop")
     depends_on("libtool", type="build", when="@develop")
     depends_on("m4", type="build", when="@develop")
+    depends_on("mpi", when="+mpi")
 
     depends_on("blas")
     depends_on("gsl@1.9:")
     depends_on("lapack")
+
+    # The library of exchange and correlation functionals.
     depends_on("libxc@2:2", when="@:5")
     depends_on("libxc@2:3", when="@6:7")
     depends_on("libxc@2:4", when="@8:9")
     depends_on("libxc@5.1.0:", when="@10:")
     depends_on("libxc@5.1.0:", when="@develop")
-    depends_on("mpi")
-    depends_on("fftw@3:+mpi+openmp", when="@8:9")
-    depends_on("fftw-api@3:+mpi+openmp", when="@10:")
+    with when("+mpi"):  # list all the parallel dependencies
+        depends_on("fftw@3:+mpi+openmp", when="@8:9")  # FFT library
+        depends_on("fftw-api@3:+mpi+openmp", when="@10:")
+        depends_on("libvdwxc+mpi", when="+libvdwxc")
+        depends_on("arpack-ng+mpi", when="+arpack")
+        depends_on("elpa+mpi", when="+elpa")
+        depends_on("netcdf-fortran ^netcdf-c+mpi", when="+netcdf")
+
+    with when("~mpi"):  # list all the serial dependencies
+        depends_on("fftw@3:+openmp~mpi", when="@8:9")  # FFT library
+        depends_on("fftw-api@3:+openmp~mpi", when="@10:")
+        depends_on("libvdwxc~mpi", when="+libvdwxc")
+        depends_on("arpack-ng~mpi", when="+arpack")
+        depends_on("elpa~mpi", when="+elpa")
+        depends_on("netcdf-fortran ^netcdf-c~~mpi", when="+netcdf")
+
     depends_on("py-numpy", when="+python")
     depends_on("py-mpi4py", when="+python")
     depends_on("metis@5:+int64", when="+metis")
     depends_on("parmetis+int64", when="+parmetis")
     depends_on("scalapack", when="+scalapack")
-    depends_on("netcdf-fortran", when="+netcdf")
-    depends_on("arpack-ng", when="+arpack")
     depends_on("cgal", when="+cgal")
     depends_on("pfft", when="+pfft")
     depends_on("likwid", when="+likwid")
-    depends_on("libvdwxc", when="+libvdwxc")
     depends_on("libyaml", when="+libyaml")
-    depends_on("elpa", when="+elpa")
     depends_on("nlopt", when="+nlopt")
 
     # optional dependencies:
@@ -103,12 +116,25 @@ class Octopus(AutotoolsPackage, CudaPackage):
                 "--with-lapack=%s" % lapack.ld_flags,
                 "--with-gsl-prefix=%s" % spec["gsl"].prefix,
                 "--with-libxc-prefix=%s" % spec["libxc"].prefix,
-                "CC=%s" % spec["mpi"].mpicc,
-                "FC=%s" % spec["mpi"].mpifc,
-                "--enable-mpi",
                 "--enable-openmp",
             ]
         )
+        if "+mpi" in self.spec:  # we build with MPI
+            args.extend(
+                [
+                    "--enable-mpi",
+                    "CC=%s" % self.spec["mpi"].mpicc,
+                    "FC=%s" % self.spec["mpi"].mpifc,
+                ]
+            )
+        else:
+            args.extend(
+                [
+                    "CC=%s" % self.compiler.cc,
+                    "FC=%s" % self.compiler.fc,
+                ]
+            )
+
         if "^fftw" in spec:
             args.append("--with-fftw-prefix=%s" % spec["fftw"].prefix)
         elif "^mkl" in spec:


### PR DESCRIPTION
- Fix psolver compilation
- fix berkelygw mpi variant
- add nfft 3.2.4

These changes were already included in our spack fork for dev-23a release, and are now also being applied for the 23b release