### PR TITLE
Patches to compile mpsd/v0.19_23b with glibc 2.36

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/glibc-2.36-libarchive-1.patch
+++ b/var/spack/repos/builtin/packages/cmake/glibc-2.36-libarchive-1.patch
@@ -1,0 +1,41 @@
+From a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 10:56:53 -0700
+Subject: [PATCH] libarchive: Do not include sys/mount.h when linux/fs.h is
+ present
+
+These headers are in conflict and only one is needed by
+archive_read_disk_posix.c therefore include linux/fs.h if it exists
+otherwise include sys/mount.h
+
+It also helps compiling with glibc 2.36
+where sys/mount.h conflicts with linux/mount.h see [1]
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+---
+ libarchive/archive_read_disk_posix.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c b/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
+index 2b39e672b..a96008db7 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
+@@ -34,9 +34,6 @@ __FBSDID("$FreeBSD$");
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif
+-#ifdef HAVE_SYS_MOUNT_H
+-#include <sys/mount.h>
+-#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+@@ -54,6 +51,8 @@ __FBSDID("$FreeBSD$");
+ #endif
+ #ifdef HAVE_LINUX_FS_H
+ #include <linux/fs.h>
++#elif HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
+ #endif
+ /*
+  * Some Linux distributions have both linux/ext2_fs.h and ext2fs/ext2_fs.h.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -269,6 +269,8 @@ class Cmake(Package):
         when="@3.19.0:3.19",
     )
 
+    patch("glibc-2.36-libarchive-1.patch", when="@3.26.3")
+
     conflicts("+qt", when="^qt@5.4.0")  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -187,6 +187,8 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 options.append(
                     "--with-{0}-compute-capability=sm_{1}".format(cuda_flag.upper(), cuda_arch)
                 )
+
+            options.append("NVCCFLAGS=-D__GNUC__=10")
         else:
             options.append("--disable-{0}".format(cuda_flag))
 

--- a/var/spack/repos/builtin/packages/gcc/glibc-2.36-libsanitizer-1.patch
+++ b/var/spack/repos/builtin/packages/gcc/glibc-2.36-libsanitizer-1.patch
@@ -1,0 +1,54 @@
+From b379129c4beb3f26223288627a1291739f33af02 Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Mon, 11 Jul 2022 11:38:28 -0700
+Subject: [PATCH] [sanitizer] Remove #include <linux/fs.h> to resolve
+ fsconfig_command/mount_attr conflict with glibc 2.36
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is generally not a good idea to mix usage of glibc headers and Linux UAPI
+headers (https://sourceware.org/glibc/wiki/Synchronizing_Headers). In glibc
+since 7eae6a91e9b1670330c9f15730082c91c0b1d570 (milestone: 2.36), sys/mount.h
+defines `fsconfig_command` which conflicts with linux/mount.h:
+
+    .../usr/include/linux/mount.h:95:6: error: redeclaration of ‘enum fsconfig_command’
+
+Remove #include <linux/fs.h> which pulls in linux/mount.h. Expand its 4 macros manually.
+
+Fix https://github.com/llvm/llvm-project/issues/56421
+
+Reviewed By: #sanitizers, vitalybuka, zatrazz
+
+Differential Revision: https://reviews.llvm.org/D129471
+---
+ .../sanitizer_common/sanitizer_platform_limits_posix.cpp | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 4bd425435d56d9..81740bf4ab3948 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -73,7 +73,6 @@
+ #include <sys/vt.h>
+ #include <linux/cdrom.h>
+ #include <linux/fd.h>
+-#include <linux/fs.h>
+ #include <linux/hdreg.h>
+ #include <linux/input.h>
+ #include <linux/ioctl.h>
+@@ -876,10 +875,10 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_EVIOCGPROP = IOCTL_NOT_PRESENT;
+   unsigned IOCTL_EVIOCSKEYCODE_V2 = IOCTL_NOT_PRESENT;
+ #endif
+-  unsigned IOCTL_FS_IOC_GETFLAGS = FS_IOC_GETFLAGS;
+-  unsigned IOCTL_FS_IOC_GETVERSION = FS_IOC_GETVERSION;
+-  unsigned IOCTL_FS_IOC_SETFLAGS = FS_IOC_SETFLAGS;
+-  unsigned IOCTL_FS_IOC_SETVERSION = FS_IOC_SETVERSION;
++  unsigned IOCTL_FS_IOC_GETFLAGS = _IOR('f', 1, long);
++  unsigned IOCTL_FS_IOC_GETVERSION = _IOR('v', 1, long);
++  unsigned IOCTL_FS_IOC_SETFLAGS = _IOW('f', 2, long);
++  unsigned IOCTL_FS_IOC_SETVERSION = _IOW('v', 2, long);
+   unsigned IOCTL_GIO_CMAP = GIO_CMAP;
+   unsigned IOCTL_GIO_FONT = GIO_FONT;
+   unsigned IOCTL_GIO_UNIMAP = GIO_UNIMAP;

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -423,6 +423,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     patch("glibc-2.31-libsanitizer-2.patch", when="@8.1.0:8.3.0,9.0.0:9.2.0")
     patch("glibc-2.31-libsanitizer-2-gcc-6.patch", when="@5.3.0:5.5.0,6.1.0:6.5.0")
     patch("glibc-2.31-libsanitizer-2-gcc-7.patch", when="@7.1.0:7.5.0")
+    patch("glibc-2.36-libsanitizer-1.patch", when="@11.3.0")
     patch(
         "patch-2b40941d23b1570cdd90083b58fa0f66aa58c86e.patch",
         when="@6.5.0,7.4.0:7.5.0,8.2.0:9.3.0",

--- a/var/spack/repos/builtin/packages/knem/cpus_cpumask.patch
+++ b/var/spack/repos/builtin/packages/knem/cpus_cpumask.patch
@@ -1,0 +1,85 @@
+From c9b6416461284e064a1c511ec883db610da638ca Mon Sep 17 00:00:00 2001
+From: Philipp Friese <philipp.friese@in.tum.de>
+Date: Fri, 28 Jul 2023 14:47:24 +0200
+Subject: [PATCH] driver/linux: Update detection of cpus_*/cpumask_* functions
+
+Kernel 2.6.28 deprecated cpus_{setall,complement} in favour of cpumask_{setall,complement}.
+Kernel 6.3 removes cpumask_complement (commit 596ff4a09b8981790e15572e8e7bc904df5835e7).
+
+This commit adds an implementation of knem_cpumask_complement for kernels 6.3+
+based on the removed cpumask_complement.
+
+Separate the check for *_setall() since cpumask_setall() isn't removed.
+
+Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>
+---
+ driver/linux/check_kernel_headers.sh | 19 ++++++++++++++++++-
+ driver/linux/knem_hal.h              | 12 ++++++++++--
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/driver/linux/check_kernel_headers.sh b/driver/linux/check_kernel_headers.sh
+index 4b4b9b3..28e357f 100755
+--- a/driver/linux/check_kernel_headers.sh
++++ b/driver/linux/check_kernel_headers.sh
+@@ -157,7 +157,7 @@ else
+   echo no
+ fi
+ 
+-# cpumask_complement deprecates cpus_complement in 2.6.27, and the latter is removed in 2.6.32
++# cpumask_complement deprecates cpus_complement in 2.6.28, cpus_complement is removed in 4.1, cpumask_complement is removed in 6.3
+ echo -n "  checking (in kernel headers) cpumask_complement() availability ... "
+ if grep cpumask_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
+   echo "#define KNEM_HAVE_CPUMASK_COMPLEMENT 1" >> ${TMP_CHECKS_NAME}
+@@ -165,6 +165,23 @@ if grep cpumask_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; th
+ else
+   echo no
+ fi
++echo -n "  checking (in kernel headers) cpus_complement() availability ... "
++if grep cpus_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
++  echo "#define KNEM_HAVE_CPUS_COMPLEMENT 1" >> ${TMP_CHECKS_NAME}
++  echo yes
++else
++  echo no
++fi
++
++# cpumask_setall deprecates cpus_setall in 2.6.28
++echo -n "  checking (in kernel headers) cpumask_setall() availability ... "
++if grep cpumask_setall ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
++  echo "#define KNEM_HAVE_CPUMASK_SETALL 1" >> ${TMP_CHECKS_NAME}
++  echo yes
++else
++  echo no
++fi
++
+ 
+ # set_cpus_allowed_ptr added in 2.6.26, and set_cpus_allowed dropped in 2.6.34
+ # set_cpus_allowed_ptr backported in redhat 5 kernels but not exported to modules
+diff --git a/driver/linux/knem_hal.h b/driver/linux/knem_hal.h
+index 44dc41a..cee1f6b 100644
+--- a/driver/linux/knem_hal.h
++++ b/driver/linux/knem_hal.h
+@@ -238,11 +238,19 @@ knem_unpin_user_page_dirty_lock(struct page *page, bool make_dirty)
+ }
+ #endif /* !KNEM_HAVE_UNPIN_USER_PAGES_DIRTY_LOCK */
+ 
+-#ifdef KNEM_HAVE_CPUMASK_COMPLEMENT
++/* Kernel 2.6.28 deprecates cpus_complement for cpumask_complement. Kernel 6.3 removes cpumask_complement. */
++#if defined KNEM_HAVE_CPUMASK_COMPLEMENT /* kernel 2.6.28 to 6.2 */
+ #define knem_cpumask_complement cpumask_complement
++#elif defined KNEM_HAVE_CPUS_COMPLEMENT /* kernel < 2.6.28 */
++#define knem_cpumask_complement(a,b) cpus_complement(*(a), *(b))
++#else /* kernel >= 6.3 */
++#define knem_cpumask_complement(a,b) bitmap_complement(cpumask_bits(a), cpumask_bits(b), nr_cpu_ids)
++#endif
++
++/* Kernel 2.6.28 deprecates cpus_setall for cpumask_setall. */
++#ifdef KNEM_HAVE_CPUMASK_SETALL
+ #define knem_cpumask_setall cpumask_setall
+ #else
+-#define knem_cpumask_complement(a,b) cpus_complement(*(a), *(b))
+ #define knem_cpumask_setall(m) cpus_setall(*(m))
+ #endif
+ 
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/knem/package.py
+++ b/var/spack/repos/builtin/packages/knem/package.py
@@ -37,6 +37,8 @@ class Knem(AutotoolsPackage):
         when="@1.1.4",
     )
 
+    patch("cpus_cpumask.patch", when="@:1.1.4")
+
     depends_on("hwloc", when="+hwloc")
     depends_on("pkgconfig", type="build", when="+hwloc")
     depends_on("autoconf", type="build", when="@master")
@@ -63,7 +65,9 @@ class Knem(AutotoolsPackage):
         make.add_default_arg("CC={0}".format(spack_cc))
 
     def configure_args(self):
-        return self.enable_or_disable("hwloc")
+        args = self.enable_or_disable("hwloc")
+        args.extend(["KBUILD_ARGS=CONFIG_INIT_STACK_ALL_ZERO= CONFIG_INIT_STACK_ALL_PATTERN="])
+        return args
 
     @when("@master")
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/openblas/openblas_parallel_build.patch
+++ b/var/spack/repos/builtin/packages/openblas/openblas_parallel_build.patch
@@ -1,0 +1,31 @@
+From bb7ae98dfdbdc7b964611fc42223a4fdeac4caaa Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <me@harmenstoppels.nl>
+Date: Wed, 8 Feb 2023 12:52:22 +0100
+Subject: [PATCH] fix shared and tests prereqs
+
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0b920cc9fe..1c99487912 100644
+--- a/Makefile
++++ b/Makefile
+@@ -110,7 +110,7 @@ endif
+ 	@echo "To install the library, you can run \"make PREFIX=/path/to/your/installation install\"."
+ 	@echo
+ 
+-shared :
++shared : libs netlib $(RELA)
+ ifneq ($(NO_SHARED), 1)
+ ifeq ($(OSNAME), $(filter $(OSNAME),Linux SunOS Android Haiku))
+ 	@$(MAKE) -C exports so
+@@ -134,7 +134,7 @@ ifeq ($(OSNAME), CYGWIN_NT)
+ endif
+ endif
+ 
+-tests :
++tests : libs netlib $(RELA) shared
+ ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
+ 	touch $(LIBNAME)
+ ifndef NO_FBLAS

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -168,6 +168,8 @@ class Openblas(MakefilePackage):
     # See <https://github.com/xianyi/OpenBLAS/issues/3760>
     patch("linktest.patch", when="@0.3.20")
 
+    patch("openblas_parallel_build.patch", when="@:0.3.22")
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     conflicts("%gcc@7.0.0:7.3,8.0.0:8.2", when="@0.3.11:")
 


### PR DESCRIPTION
Fedora 39 ships with glibc 2.38 and since glibc 2.36 the `fsconfig` syscall is exposed which conflicts with the implementation in libsanitizer. This PR backports https://github.com/llvm/llvm-project/commit/b379129c4beb3f26223288627a1291739f33af02 to GCC and https://github.com/libarchive/libarchive/commit/a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f to CMake circumvent this. However, it is unclear whether this also works for systems with glibc older than 2.36 which is why this is marked as draft.

Furthermore I ran into a race condition in the OpenBLAS build. To fix that I had to backport https://github.com/OpenMathLib/OpenBLAS/commit/bb7ae98dfdbdc7b964611fc42223a4fdeac4caaa because GNU make has started parallelizing over command line targets in version 4.4.

The `cpus_setall` and `cpus_complement` Kernel APIs have been removed in Linux 6.3 or so and to make knem compile against a new kernel I have to backport https://gitlab.inria.fr/knem/knem/-/commit/c9b6416461284e064a1c511ec883db610da638ca and also override two Kconfig settings to prevent the Makefile from using the `-ftrivial-auto-var-init` flag which is not supported by GCC 11.

CUDA 11.4 also doesn't like glibc newer than 2.34 because this uses a two-argument version of `__attribute__((malloc))` introduced in GCC 11  which is not supported by NVCC. In fact, CUDA 11.4 is therefore incompatible with GCC 11, so the entire toolchain just works out of pure luck.