### PR TITLE
Patches to compile mpsd/v0.21_develop with glibc 2.36

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/glibc-2.36-libarchive-1.patch
+++ b/var/spack/repos/builtin/packages/cmake/glibc-2.36-libarchive-1.patch
@@ -1,0 +1,41 @@
+From a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 10:56:53 -0700
+Subject: [PATCH] libarchive: Do not include sys/mount.h when linux/fs.h is
+ present
+
+These headers are in conflict and only one is needed by
+archive_read_disk_posix.c therefore include linux/fs.h if it exists
+otherwise include sys/mount.h
+
+It also helps compiling with glibc 2.36
+where sys/mount.h conflicts with linux/mount.h see [1]
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+---
+ libarchive/archive_read_disk_posix.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c b/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
+index 2b39e672b..a96008db7 100644
+--- a/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
++++ b/Utilities/cmlibarchive/libarchive/archive_read_disk_posix.c
+@@ -34,9 +34,6 @@ __FBSDID("$FreeBSD$");
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif
+-#ifdef HAVE_SYS_MOUNT_H
+-#include <sys/mount.h>
+-#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+@@ -54,6 +51,8 @@ __FBSDID("$FreeBSD$");
+ #endif
+ #ifdef HAVE_LINUX_FS_H
+ #include <linux/fs.h>
++#elif HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
+ #endif
+ /*
+  * Some Linux distributions have both linux/ext2_fs.h and ext2fs/ext2_fs.h.

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -190,6 +190,8 @@ class Cmake(Package):
         when="@3.15.5",
     )
 
+    patch("glibc-2.36-libarchive-1.patch", when="@:3.26.3")
+
     depends_on("ninja", when="platform=windows")
 
     # We default ownlibs to true because it greatly speeds up the CMake

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -176,6 +176,12 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
                 options.append(
                     "--with-{0}-compute-capability=sm_{1}".format(cuda_flag.upper(), cuda_arch)
                 )
+
+            # CUDA 11.4 pretends to support GCC 11, but in fact does not.  So if
+            # CUDA is 11.4 or less and GCC is newer than 10 we pretend that we
+            # only have GCC 10.
+            if spec["cuda"].version < Version("11.5") and spec.compiler.version > Version("10"):
+                options.append("NVCCFLAGS=-D__GNUC__=10")
         else:
             options.append("--disable-{0}".format(cuda_flag))
 

--- a/var/spack/repos/builtin/packages/knem/cpus_cpumask.patch
+++ b/var/spack/repos/builtin/packages/knem/cpus_cpumask.patch
@@ -1,0 +1,85 @@
+From c9b6416461284e064a1c511ec883db610da638ca Mon Sep 17 00:00:00 2001
+From: Philipp Friese <philipp.friese@in.tum.de>
+Date: Fri, 28 Jul 2023 14:47:24 +0200
+Subject: [PATCH] driver/linux: Update detection of cpus_*/cpumask_* functions
+
+Kernel 2.6.28 deprecated cpus_{setall,complement} in favour of cpumask_{setall,complement}.
+Kernel 6.3 removes cpumask_complement (commit 596ff4a09b8981790e15572e8e7bc904df5835e7).
+
+This commit adds an implementation of knem_cpumask_complement for kernels 6.3+
+based on the removed cpumask_complement.
+
+Separate the check for *_setall() since cpumask_setall() isn't removed.
+
+Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>
+---
+ driver/linux/check_kernel_headers.sh | 19 ++++++++++++++++++-
+ driver/linux/knem_hal.h              | 12 ++++++++++--
+ 2 files changed, 28 insertions(+), 3 deletions(-)
+
+diff --git a/driver/linux/check_kernel_headers.sh b/driver/linux/check_kernel_headers.sh
+index 4b4b9b3..28e357f 100755
+--- a/driver/linux/check_kernel_headers.sh
++++ b/driver/linux/check_kernel_headers.sh
+@@ -157,7 +157,7 @@ else
+   echo no
+ fi
+ 
+-# cpumask_complement deprecates cpus_complement in 2.6.27, and the latter is removed in 2.6.32
++# cpumask_complement deprecates cpus_complement in 2.6.28, cpus_complement is removed in 4.1, cpumask_complement is removed in 6.3
+ echo -n "  checking (in kernel headers) cpumask_complement() availability ... "
+ if grep cpumask_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
+   echo "#define KNEM_HAVE_CPUMASK_COMPLEMENT 1" >> ${TMP_CHECKS_NAME}
+@@ -165,6 +165,23 @@ if grep cpumask_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; th
+ else
+   echo no
+ fi
++echo -n "  checking (in kernel headers) cpus_complement() availability ... "
++if grep cpus_complement ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
++  echo "#define KNEM_HAVE_CPUS_COMPLEMENT 1" >> ${TMP_CHECKS_NAME}
++  echo yes
++else
++  echo no
++fi
++
++# cpumask_setall deprecates cpus_setall in 2.6.28
++echo -n "  checking (in kernel headers) cpumask_setall() availability ... "
++if grep cpumask_setall ${LINUX_HDR}/include/linux/cpumask.h > /dev/null ; then
++  echo "#define KNEM_HAVE_CPUMASK_SETALL 1" >> ${TMP_CHECKS_NAME}
++  echo yes
++else
++  echo no
++fi
++
+ 
+ # set_cpus_allowed_ptr added in 2.6.26, and set_cpus_allowed dropped in 2.6.34
+ # set_cpus_allowed_ptr backported in redhat 5 kernels but not exported to modules
+diff --git a/driver/linux/knem_hal.h b/driver/linux/knem_hal.h
+index 44dc41a..cee1f6b 100644
+--- a/driver/linux/knem_hal.h
++++ b/driver/linux/knem_hal.h
+@@ -238,11 +238,19 @@ knem_unpin_user_page_dirty_lock(struct page *page, bool make_dirty)
+ }
+ #endif /* !KNEM_HAVE_UNPIN_USER_PAGES_DIRTY_LOCK */
+ 
+-#ifdef KNEM_HAVE_CPUMASK_COMPLEMENT
++/* Kernel 2.6.28 deprecates cpus_complement for cpumask_complement. Kernel 6.3 removes cpumask_complement. */
++#if defined KNEM_HAVE_CPUMASK_COMPLEMENT /* kernel 2.6.28 to 6.2 */
+ #define knem_cpumask_complement cpumask_complement
++#elif defined KNEM_HAVE_CPUS_COMPLEMENT /* kernel < 2.6.28 */
++#define knem_cpumask_complement(a,b) cpus_complement(*(a), *(b))
++#else /* kernel >= 6.3 */
++#define knem_cpumask_complement(a,b) bitmap_complement(cpumask_bits(a), cpumask_bits(b), nr_cpu_ids)
++#endif
++
++/* Kernel 2.6.28 deprecates cpus_setall for cpumask_setall. */
++#ifdef KNEM_HAVE_CPUMASK_SETALL
+ #define knem_cpumask_setall cpumask_setall
+ #else
+-#define knem_cpumask_complement(a,b) cpus_complement(*(a), *(b))
+ #define knem_cpumask_setall(m) cpus_setall(*(m))
+ #endif
+ 
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/knem/package.py
+++ b/var/spack/repos/builtin/packages/knem/package.py
@@ -37,6 +37,8 @@ class Knem(AutotoolsPackage):
         when="@1.1.4",
     )
 
+    patch("cpus_cpumask.patch", when="@:1.1.4")
+
     depends_on("hwloc", when="+hwloc")
     depends_on("pkgconfig", type="build", when="+hwloc")
     depends_on("autoconf", type="build", when="@master")
@@ -58,7 +60,9 @@ class Knem(AutotoolsPackage):
         make.add_default_arg("CC={0}".format(spack_cc))
 
     def configure_args(self):
-        return self.enable_or_disable("hwloc")
+        args = self.enable_or_disable("hwloc")
+        args.extend(["KBUILD_ARGS=CONFIG_INIT_STACK_ALL_ZERO= CONFIG_INIT_STACK_ALL_PATTERN="])
+        return args
 
     @when("@master")
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
Same as https://github.com/mpsd-computational-science/spack/pull/18, but targeting `mpsd/v0.21_develop`.